### PR TITLE
Update node-ses dependency to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parse-server-simple-ses-adapter",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Used to send Parse Server password reset and email verification emails though ses",
   "main": "index.js",
   "scripts": {
@@ -22,6 +22,6 @@
   },
   "homepage": "https://github.com/ericraio/parse-server-simple-ses-adapter#readme",
   "dependencies": {
-    "node-ses": "1.2.0"
+    "node-ses": "3.0.2"
   }
 }


### PR DESCRIPTION
flos ブランチに向けた PR です。

https://github.com/ericraio/parse-server-simple-ses-adapter/pull/5
と同じ対応をする。

バージョニングのルールわからないけどオリジナルに合わせて 1.1.0 にしておく。